### PR TITLE
Remove refernces to IIFE syntax. Replace with module where applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,14 @@ This is Swedish, so please choose other languages. You can add as many words/tra
 1. One team member creates a Github project and adds the others as collaborators.
 1. Each team member picks a language.
 1. Your project should have one HTML file that has a textarea, a select element with an option for each language, a button with a label of "Translate", and an empty DOM element into which the translated text will be inserted.
-1. The team must discuss and choose a single variable name that will hold all of the logic that the team creates.
-1. Each team member will create one JavaScript file that contains one IIFE. Each teammate's IIFE will augment the other teammates' IIFEs.
+1. Each team member will create one JavaScript file that contains one module that translates an English holiday greeting into another language.
 1. The lexicon should be a private variable that cannot be accessed by the other team member's module except through an accessor (getter) method.
-1. Each IIFE should expose, in its public interface, a method named `translateTo{Language}` (e.g. `translateToSpanish` or `translateToFinnish`) that accepts a single argument. That argument's value should be the text entered in by the user. The method should return the translated text.
+1. Each module should expose, in its public interface, a method named `translateTo{Language}` (e.g. `translateToSpanish` or `translateToFinnish`) that accepts a single argument. That argument's value should be the text entered in by the user. The method should return the translated text.
 1. The team should create an extra JavaScript file that handles interacting with the form elements and determining which method should be called.
-
-> **Optional Bonus 1**
->
-> Find a way to write your IIFEs so that it doesn't matter whose module gets created first.
 
 ---
 
-> **Optional Bonus 2**
+> **Optional Bonus **
 >
 > In addition to inserting the translated text into the HTML document, have the browser read the translated text to the user.
 >


### PR DESCRIPTION
Another stage in the dialing back of IIFE syntax. I've left it vague, with no specific mention of Browserify of Grunt, so it can be used with WebPack, Gulp, or whatever.